### PR TITLE
INTERNAL: Convert data to json request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
         "@tsconfig/svelte": "^2.0.1",
         "autoprefixer": "^10.4.0",
-        "nanoid": "^3.1.30",
         "postcss": "^8.4.4",
         "prettier": "*",
         "prettier-plugin-svelte": "*",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
     "@tsconfig/svelte": "^2.0.1",
     "autoprefixer": "^10.4.0",
-    "nanoid": "^3.1.30",
     "postcss": "^8.4.4",
     "prettier": "*",
     "prettier-plugin-svelte": "*",

--- a/public/catscradle.json
+++ b/public/catscradle.json
@@ -1,0 +1,79 @@
+[
+  {
+    "chapter": 1,
+    "passages": [
+      {
+        "html": "Call me Jonah. My parents did, or nearly did. They called me John.",
+        "chapter": 1
+      },
+      {
+        "html": "Jonah–John–if I had been a Sam, I would have been a Jonah still–not because I have been unlucky for others, but because somebody or something has compelled me to be certain places at certain times, without fail. Conveyances and motives, both conventional and bizarre, have been provided. And, according to plan, at each appointed second, at each appointed place this Jonah was there.",
+        "chapter": 1
+      },
+      { "html": "Listen:", "chapter": 1 },
+      {
+        "html": "When I was a younger man–two wives ago, 250,000 cigarettes ago, 3000 quarts of beer ago…",
+        "chapter": 1
+      },
+      {
+        "html": "When I was a much younger man, I began to collect material for a book to be called <em>The Day the World Ended</em>.",
+        "chapter": 1
+      },
+      { "html": "The book was to be factual.", "chapter": 1 },
+      {
+        "html": "The book was to be an account of what important Americans had done on the day when the first atomic bomb was dropped on Hiroshima, Japan.",
+        "chapter": 1
+      },
+      { "html": "It was to be a Christian book. I was a Christian then.", "chapter": 1 },
+      { "html": "I am a Bokononist now.", "chapter": 1 },
+      {
+        "html": "I would have been a Bokononist then, if there had been anyone to teach me the bittersweet lies of Bokonon. But Bokononism was unknown beyond the gravel beaches and coral knives that ring this little island in the Caribbean Sea, the Republic of San Lorenzo.",
+        "chapter": 1
+      },
+      {
+        "html": "We Bokononists believe that humanity is organized into teams, teams that do God's Will without ever discovering what they are doing. Such a team is called a <em>karass</em> by Bokonon, and the instrument, the <em>kan-kan</em>, that brought me into my own particular <em>karass</em> was the book I never finished, the book to be called <em>The Day the World Ended</em>.",
+        "chapter": 1
+      }
+    ]
+  },
+  {
+    "chapter": 2,
+    "passages": [
+      {
+        "html": "\"If you find your life tangled up with somebody else's life for no very logical reasons,\" writes Bokonon, \"that person may be a member of your <em>karass</em>.\"",
+        "chapter": 2
+      },
+      {
+        "html": "At another point in <em>The Books of Bokonon</em> he tells us, \"Man created the checkerboard; God created the <em>karass</em>.\" By that he means that a <em>karass</em> ignores national, institutional, occupational, familial, and class boundaries.",
+        "chapter": 2
+      },
+      { "html": "It is as free-form as an amoeba.", "chapter": 2 },
+      {
+        "html": "In his \"Fifty-third Calypso,\" Bokonon invites us to sing along with him:",
+        "chapter": 2
+      },
+      { "html": "Oh, a sleeping drunkard", "chapter": 2 },
+      { "html": "Up in Central Park,", "chapter": 2 },
+      { "html": "And a lion-hunter", "chapter": 2 },
+      { "html": "In the jungle dark,", "chapter": 2 },
+      { "html": "And a Chinese dentist,", "chapter": 2 },
+      { "html": "And a British queen–", "chapter": 2 },
+      { "html": "All fit together", "chapter": 2 },
+      { "html": "In the same machine.", "chapter": 2 },
+      { "html": "Nice, nice, very nice;", "chapter": 2 },
+      { "html": "Nice, nice, very nice;", "chapter": 2 },
+      { "html": "Nice, nice, very nice–", "chapter": 2 },
+      { "html": "So many different people", "chapter": 2 },
+      { "html": "In the same device", "chapter": 2 }
+    ]
+  },
+  {
+    "chapter": 3,
+    "passages": [
+      {
+        "html": "Nowhere does Bokonon warn against a person's trying to discover the limits of his <em>karass</em> and the nature of the work God Almighty has had it do. Bokonon simply observes that such investigations are bound to be incomplete.",
+        "chapter": 3
+      }
+    ]
+  }
+]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
-  import { catsCradle } from '../tests/catsCradle';
+  import { onMount } from 'svelte';
 
   import Chapter from './Chapter.svelte';
   import Passage from './Passage.svelte';
+
+  let chapters = [];
+
+  onMount(async () => {
+    const response = await fetch('catscradle.json');
+    chapters = await response.json();
+  });
 </script>
 
 <main class="max-w-prose mx-auto">
-  {#each catsCradle as { chapter, passages }}
+  {#each chapters as { chapter, passages }}
     <section class="text-xl leading-relaxed">
       <Chapter>{chapter}</Chapter>
       {#each passages as passage}

--- a/src/Passage.svelte
+++ b/src/Passage.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  export let id;
   export let html;
   export let chapter;
 </script>
 
-<p {id} class="font-serif dark:text-gray-50 indent-6">
+<p class="font-serif dark:text-gray-50 indent-6">
   {@html html}
 </p>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,9 +1,6 @@
-type NanoID = string;
-
 export interface Passage {
   chapter: number;
   html: string;
-  id: NanoID;
 }
 
 export interface Chapter {

--- a/tests/catsCradle.ts
+++ b/tests/catsCradle.ts
@@ -1,5 +1,4 @@
 import type { Chapter, Passage } from '../src/types';
-import { nanoid } from 'nanoid/non-secure';
 
 const chapter1: Passage[] = [
   'Call me Jonah. My parents did, or nearly did. They called me John.',
@@ -14,7 +13,7 @@ const chapter1: Passage[] = [
   'I would have been a Bokononist then, if there had been anyone to teach me the bittersweet lies of Bokonon. But Bokononism was unknown beyond the gravel beaches and coral knives that ring this little island in the Caribbean Sea, the Republic of San Lorenzo.',
   "We Bokononists believe that humanity is organized into teams, teams that do God's Will without ever discovering what they are doing. Such a team is called a <em>karass</em> by Bokonon, and the instrument, the <em>kan-kan</em>, that brought me into my own particular <em>karass</em> was the book I never finished, the book to be called <em>The Day the World Ended</em>.",
 ].map((passage) => {
-  return { id: nanoid(), html: passage, chapter: 1 };
+  return { html: passage, chapter: 1 };
 });
 
 const chapter2: Passage[] = [
@@ -36,10 +35,17 @@ const chapter2: Passage[] = [
   'So many different people',
   'In the same device',
 ].map((passage) => {
-  return { id: nanoid(), html: passage, chapter: 2 };
+  return { html: passage, chapter: 2 };
+});
+
+const chapter3: Passage[] = [
+  "Nowhere does Bokonon warn against a person's trying to discover the limits of his <em>karass</em> and the nature of the work God Almighty has had it do. Bokonon simply observes that such investigations are bound to be incomplete.",
+].map((passage) => {
+  return { html: passage, chapter: 3 };
 });
 
 export const catsCradle: Chapter[] = [
   { chapter: 1, passages: chapter1 },
   { chapter: 2, passages: chapter2 },
+  { chapter: 3, passages: chapter3 },
 ];


### PR DESCRIPTION
This PR:
1. Removes `nanoid` because it's not actually necessary right now. The passage will have some sort of ID, but probably a wallet and there's no need to generate dummy IDs
2. Converts the passages from importing a JS file to requesting a JSON file to get closer to what the real request will be